### PR TITLE
Detachable tabs: reposition preferences code

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -337,6 +337,9 @@ class PrefsEditor:
         # DBus Server
         widget = guiget('dbuscheck')
         widget.set_active(self.config['dbus'])
+        # Detachable tabs
+        widget = guiget('detachable_tabs')
+        widget.set_active(self.config['detachable_tabs'])
         #Hide from taskbar
         widget = guiget('hidefromtaskbcheck')
         widget.set_active(self.config['hide_from_taskbar'])
@@ -770,10 +773,6 @@ class PrefsEditor:
         else:
             widget.set_font_name(self.config['title_font'])
 
-        # Whether tabs can be detached into their own window by dragging from titlebar
-        widget = guiget('detachable_tabs')
-        widget.set_active(self.config['detachable_tabs'])
-
     def set_layout(self, layout_name):
         """Set a layout"""
         self.layouteditor.set_layout(layout_name)
@@ -803,6 +802,10 @@ class PrefsEditor:
     def on_dbuscheck_toggled(self, widget):
         """DBus server setting changed"""
         self.config['dbus'] = widget.get_active()
+        self.config.save()
+
+    def on_detachable_tabs_toggled(self, widget):
+        self.config['detachable_tabs'] = widget.get_active()
         self.config.save()
 
     def on_disable_mousewheel_zoom_toggled(self, widget):
@@ -1876,10 +1879,6 @@ class PrefsEditor:
     def on_open_manual(self,  widget):
         """Open the fine manual"""
         self.term.key_help()
-
-    def on_detachable_tabs_toggled(self, widget):
-        self.config['detachable_tabs'] = widget.get_active()
-        self.config.save()
 
 class LayoutEditor:
     profile_ids_to_profile = None


### PR DESCRIPTION
The feature seems to work as it should, thanks for the help!

This PR moves the initialization code for the "Detachable tabs" checkbox to the correct function (it was in the profile settings function, now it's in the global settings function).